### PR TITLE
chore: pin rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly"
+channel = "nightly-2023-06-12"
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
 targets = ["x86_64-unknown-none", "riscv64gc-unknown-none-elf", "aarch64-unknown-none-softfloat"]


### PR DESCRIPTION
使用 2023-06-12 版本的 nightly rust（v7.7 的 os-contest 镜像中提供的较新版本）